### PR TITLE
Add basic HTML validation test

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,5 @@
+{
+  "tag-pair": true,
+  "doctype-first": true,
+  "attr-no-duplication": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # website.io
 Personal Website
+
+## Testing
+
+Run `npm test` to lint HTML files using HTMLHint.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ankit851gupta.github.io",
+  "version": "1.0.0",
+  "description": "Personal Website",
+  "main": "index.js",
+  "scripts": {
+    "test": "bash scripts/test_html.sh"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^1.1.0"
+  }
+}

--- a/scripts/test_html.sh
+++ b/scripts/test_html.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Run HTMLHint on all HTML files excluding node_modules
+npx htmlhint "**/*.html" --config .htmlhintrc --exclude "node_modules/**"


### PR DESCRIPTION
## Summary
- lint index.html with htmlhint
- expose test script via npm
- add minimal htmlhint config

## Testing
- `bash scripts/test_html.sh` *(fails: 403 Forbidden to download htmlhint)*
- `npm test` *(fails: 403 Forbidden to download htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8f0deb4832bbbb3ea24706eb974