### PR TITLE
Fix early returns in util.js to avoid undefined `$this`

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -41,17 +41,17 @@
 	 */
 	$.fn.panel = function(userConfig) {
 
-		// No elements?
-			if (this.length == 0)
-				return $this;
+                // No elements?
+                        if (this.length == 0)
+                                return this;
 
 		// Multiple elements?
 			if (this.length > 1) {
 
-				for (var i=0; i < this.length; i++)
-					$(this[i]).panel(userConfig);
+                                for (var i=0; i < this.length; i++)
+                                        $(this[i]).panel(userConfig);
 
-				return $this;
+                                return this;
 
 			}
 
@@ -306,17 +306,17 @@
 			if (typeof (document.createElement('input')).placeholder != 'undefined')
 				return $(this);
 
-		// No elements?
-			if (this.length == 0)
-				return $this;
+                // No elements?
+                        if (this.length == 0)
+                                return this;
 
 		// Multiple elements?
 			if (this.length > 1) {
 
-				for (var i=0; i < this.length; i++)
-					$(this[i]).placeholder();
+                                for (var i=0; i < this.length; i++)
+                                        $(this[i]).placeholder();
 
-				return $this;
+                                return this;
 
 			}
 


### PR DESCRIPTION
## Summary
- return `this` early in panel and placeholder plugins
- avoid referencing `$this` before it is defined

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a8ed70e0832bb4e80ca217056a72